### PR TITLE
[TAS-51] Project card and miscellaneous adjustments

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,15 +169,16 @@ export default async function Home() {
       </Section>
       <Section className="pb-16">
         <SectionTitle>Nuestros proyectos</SectionTitle>
-        <div className="flex flex-col items-center gap-3 px-2 sm:flex-row sm:justify-center">
+        <div className="flex w-full flex-col items-center gap-3 px-2 sm:flex-row sm:justify-center">
           {projectsRes.docs.slice(0, 3).map((project) => {
             return (
               <ProjectCard
                 key={project.id}
                 name={project.nombre}
+                subtitle={project.subtitulo}
                 systemType={project.tipo_sistema}
                 stack={project.tecnologias ?? []}
-                principalImage={project.imagen_principal.url}
+                thumbnail={project.imagen_principal}
               />
             );
           })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -167,7 +167,7 @@ export default async function Home() {
           })}
         </div>
       </Section>
-      <Section className="pb-16">
+      <Section classNameDiv="pb-16">
         <SectionTitle>Nuestros proyectos</SectionTitle>
         <div className="flex w-full flex-col items-center gap-3 px-2 sm:flex-row sm:justify-center">
           {projectsRes.docs.slice(0, 3).map((project) => {

--- a/src/components/project-card/project-card.tsx
+++ b/src/components/project-card/project-card.tsx
@@ -20,7 +20,7 @@ interface ProjectCardProps {
 
 export const ProjectCard: React.FC<ProjectCardProps> = (props) => {
   return (
-    <div className="flex w-full max-w-md justify-center rounded-2xl gradient-border">
+    <div className="flex w-full justify-center rounded-2xl gradient-border md:max-w-96">
       <div className="flex h-full w-full flex-col gap-2 rounded-[15px] bg-muted p-4">
         <div className="relative flex h-64 w-full justify-center md:h-48">
           <Image

--- a/src/components/project-card/project-card.tsx
+++ b/src/components/project-card/project-card.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import React from "react";
 
 import { Button } from "@/components/ui/button";
+import { Media } from "@/models/media";
 import { Technology } from "@/models/technology";
 
 type MappedTechnology = {
@@ -11,42 +12,44 @@ type MappedTechnology = {
 
 interface ProjectCardProps {
   name: string;
+  subtitle: string;
   systemType: string;
-  description?: string;
   stack: Array<MappedTechnology>;
-  principalImage: string;
+  thumbnail: Media;
 }
 
 export const ProjectCard: React.FC<ProjectCardProps> = (props) => {
   return (
     <div className="flex w-full max-w-md justify-center rounded-2xl gradient-border">
-      <div className="h-full w-full rounded-[15px] bg-muted p-4">
-        <div className="relative flex h-72 w-full justify-center md:h-48">
-          <Image fill src="/lines.png" alt="pic" className="object-cover" />
+      <div className="flex h-full w-full flex-col gap-2 rounded-[15px] bg-muted p-4">
+        <div className="relative flex h-64 w-full justify-center md:h-48">
           <Image
             fill
-            src={`https://admin.csipro.isi.unison.mx${props.principalImage}`}
-            alt="principal_image"
+            src="/lines.png"
+            alt="Cuadrícula de fondo"
+            className="object-cover"
+          />
+          <Image
+            fill
+            src={`https://admin.csipro.isi.unison.mx${props.thumbnail.url}`}
+            alt={props.thumbnail.alt}
             className="z-10 object-contain"
           />
         </div>
-        <div className="py-2"></div>
         <div className="text-2xl font-bold">{props.name}</div>
-        <div className="flex h-14 items-center justify-between text-base font-normal">
-          <span>{props.description ?? "Lorem ipsum dolor sit amet"}</span>
+        <div className="line-clamp-2 h-12 justify-between text-base font-normal">
+          <span>{props.subtitle}</span>
         </div>
-        <div className="py-2"></div>
-        <hr className="border-1 border-primary" />
-        <div className="py-2"></div>
+        <hr className="border border-primary" />
         <div className="flex items-center justify-between">
           <div className="align-text-bottom text-sm">{props.systemType}</div>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             {props.stack.map((tech) => (
               <Image
                 key={tech.id}
-                src={`https://admin.csipro.isi.unison.mx${props.principalImage}`}
-                alt={`Technology ${tech.tecnologia.nombre}`}
-                className="h-3 w-3"
+                src={`https://admin.csipro.isi.unison.mx${tech.tecnologia.logo_monocromatico.url}`}
+                alt={tech.tecnologia.logo.alt}
+                className="size-5"
                 width={32}
                 height={32}
               />

--- a/src/components/section/section.tsx
+++ b/src/components/section/section.tsx
@@ -18,7 +18,7 @@ export const Section: FC<Props> = (props) => {
     >
       <div
         className={cn(
-          "flex w-full max-w-6xl flex-col items-center justify-center gap-4",
+          "flex w-full max-w-6xl flex-col items-center justify-center gap-4 lg:border-x lg:border-white lg:border-opacity-10",
           props.classNameDiv,
         )}
       >

--- a/src/models/media.ts
+++ b/src/models/media.ts
@@ -10,30 +10,39 @@ export const Media = z.object({
   height: z.number(),
   url: z.string(),
   sizes: z.object({
-    thumbnail: z.object({
-      width: z.number(),
-      height: z.number(),
-      mimeType: z.string(),
-      filesize: z.number(),
-      filename: z.string(),
-      url: z.string(),
-    }),
-    card: z.object({
-      width: z.number(),
-      height: z.number(),
-      mimeType: z.string(),
-      filesize: z.number(),
-      filename: z.string(),
-      url: z.string(),
-    }),
-    tablet: z.object({
-      width: z.number(),
-      height: z.number(),
-      mimeType: z.string(),
-      filesize: z.number(),
-      filename: z.string(),
-      url: z.string(),
-    }),
+    thumbnail: z
+      .object({
+        width: z.number().optional().nullable(),
+        height: z.number().optional().nullable(),
+        mimeType: z.string().optional().nullable(),
+        filesize: z.number().optional().nullable(),
+        filename: z.string().optional().nullable(),
+        url: z.string().optional().nullable(),
+      })
+      .optional()
+      .nullable(),
+    card: z
+      .object({
+        width: z.number().optional().nullable(),
+        height: z.number().optional().nullable(),
+        mimeType: z.string().optional().nullable(),
+        filesize: z.number().optional().nullable(),
+        filename: z.string().optional().nullable(),
+        url: z.string().optional().nullable(),
+      })
+      .optional()
+      .nullable(),
+    tablet: z
+      .object({
+        width: z.number().optional().nullable(),
+        height: z.number().optional().nullable(),
+        mimeType: z.string().optional().nullable(),
+        filesize: z.number().optional().nullable(),
+        filename: z.string().optional().nullable(),
+        url: z.string().optional().nullable(),
+      })
+      .optional()
+      .nullable(),
   }),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/src/models/projects.ts
+++ b/src/models/projects.ts
@@ -17,6 +17,7 @@ export const Project = z.object({
   nombre: z.string(),
   participantes: z.array(Member).optional(),
   tipo_sistema: ProjectType,
+  subtitulo: z.string(),
   imagen_principal: Media,
   imagenes_secundarias: z.array(Media).optional(),
   tecnologias: z


### PR DESCRIPTION
## Describe your changes

This PR fixes the `projects.ts` and `media.ts` models and focuses on adjusting the `<ProjectCard />` component. `<ProjectCard />` now renders the project's subtitle and its layout received some adjustments regarding image sizes, container sizes, and element spacing. Lastly, `<Section />` now renders a white border on its inner sides, just like the Figma design.

## Task URL (Asana, Jira, etc...)

[TAS-51](https://www.notion.so/Ajustes-a-secci-n-de-proyectos-036c6a37310b427b8581bfe8bfba5491?pvs=4)

## What was done in this pull request

- [x] Marked some fields on `media.ts` as `optional().nullable()` to take some cases into account, such as the CMS not being able to optimize some images (like SVGs or really small pictures).
- [x] Added the `subtitle` property to `projects.ts`.
- [x] Adjusted `<ProjectCard />` layout, sizes, and spacing between elements.
- [x] Added side borders to `<Section />`.

## Demo / Screenshot / Video

![image](https://github.com/CSIPro/csipro/assets/39208827/6366a964-650f-4c6a-9a92-c667ccf2deae)

