### PR TITLE
Refactor: Links and Nitpicks

### DIFF
--- a/src/app/eventos/page.tsx
+++ b/src/app/eventos/page.tsx
@@ -25,7 +25,7 @@ export default async function Page({
 
   return (
     <>
-      <Navbar title="EVENTOS" />
+      <Navbar titles={["TECH", "TALKS", "WORKSHOPS", "EVENTS"]} />
       <Section>
         <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-8xl -translate-x-1/2 overflow-hidden ">
           <svg

--- a/src/app/eventos/page.tsx
+++ b/src/app/eventos/page.tsx
@@ -27,7 +27,7 @@ export default async function Page({
     <>
       <Navbar titles={["TECH", "TALKS", "WORKSHOPS", "EVENTS"]} />
       <Section>
-        <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-8xl -translate-x-1/2 overflow-hidden ">
+        <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-7xl -translate-x-1/2 overflow-hidden ">
           <svg
             className="absolute inset-0 h-full w-full"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/app/eventos/page.tsx
+++ b/src/app/eventos/page.tsx
@@ -105,6 +105,7 @@ export default async function Page({
           title="Eventos"
           limit={limit}
           currentPage={currentPage}
+          hideLink
         />
       </div>
 

--- a/src/app/nosotros/page.tsx
+++ b/src/app/nosotros/page.tsx
@@ -27,7 +27,7 @@ export default function Page({
   const currentPage = Number(searchParams?.page) || 1;
   return (
     <>
-      <Navbar title="Miembros" />
+      <Navbar titles={["TEAM", "HISTORIA", "MIEMBROS", "NOSOTROS"]} />
       <Section>
         <GradientBackground />
         <GlowContainer className="">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import { LuSquareCode } from "react-icons/lu";
 import { TbSeeding } from "react-icons/tb";
@@ -142,8 +143,10 @@ export default async function Home({
               como software desarrollado por nosotros
             </p>
 
-            <Button variant="outline" className="text-base">
-              Más de nosotros
+            <Button className="text-base" asChild>
+              <Link href="/nosotros" prefetch>
+                Más de nosotros
+              </Link>
             </Button>
           </div>
         </div>
@@ -151,8 +154,20 @@ export default async function Home({
 
       <EventsSection limit={limit} currentPage={currentPage} pageLimit={2} />
       <Section classNameDiv="pb-16">
-        <SectionTitle>Nuestros proyectos</SectionTitle>
+        <div className="flex w-full items-center justify-between pr-4">
+          <SectionTitle>Nuestros proyectos</SectionTitle>
+          <Button className="hidden uppercase sm:inline-flex">
+            <Link href="/proyectos" prefetch>
+              Ver todos
+            </Link>
+          </Button>
+        </div>
         <ProjectsSection />
+        <Button className="uppercase sm:hidden">
+          <Link href="/proyectos" prefetch>
+            Ver todos
+          </Link>
+        </Button>
       </Section>
       <Footer />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ export default async function Home({
 
   return (
     <>
-      <Navbar title="BIENVENIDOS" />
+      <Navbar titles={["BIENVENIDOS", "REBOOT", "HOME"]} />
       <Section>
         <div className="absolute inset-0 -z-10 size-full overflow-hidden">
           <div className="absolute left-1/2 top-1/2 size-40 -translate-x-1/2 -translate-y-1/2 rounded-full border border-stone-400 border-opacity-10 bg-transparent sm:size-80 "></div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,8 +56,8 @@ export default async function Home({
           </GlowGroup>*/}
         </GlowContainer>
 
-        <div className="px-4 pt-10  sm:pb-6 sm:pt-20">
-          <h1 className="text-center text-4xl font-bold  sm:text-6xl ">
+        <div className="px-4 pt-10 sm:pb-4 sm:pt-12">
+          <h1 className="text-center text-4xl font-bold md:text-5xl lg:text-6xl">
             Un espacio de <span className="text-primary">desarrollo</span>,
             <br />
             <span className="text-primary"> innovación</span> &
@@ -68,13 +68,10 @@ export default async function Home({
             </span>
           </h1>
         </div>
-        <Button
-          variant="outline"
-          className="px-4 py-4 text-[14px] font-bold uppercase sm:rounded-2xl sm:px-5 sm:py-7 sm:text-2xl "
-        >
+        <Button className="px-4 py-4 font-bold uppercase sm:rounded-2xl sm:px-5 sm:py-7 sm:text-2xl ">
           Get Started
         </Button>
-        <div className="sm:py-5"></div>
+        <div className="sm:py-1"></div>
 
         <HeroCarousel images={dummyImages}>
           {dummyImages.map((img) => (
@@ -89,7 +86,7 @@ export default async function Home({
             </HeroCard>
           ))}
         </HeroCarousel>
-        <div className="py-7 sm:py-24"></div>
+        <div className="py-7 sm:py-12"></div>
       </Section>
 
       <Section>

--- a/src/app/proyectos/page.tsx
+++ b/src/app/proyectos/page.tsx
@@ -95,7 +95,7 @@ export default function Page() {
 
   return (
     <>
-      <Navbar title="Proyectos" />
+      <Navbar titles={["Dev", "Tech", "Projects"]} />
       <Section>
         <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-6xl -translate-x-1/2 overflow-hidden ">
           <svg

--- a/src/app/proyectos/page.tsx
+++ b/src/app/proyectos/page.tsx
@@ -97,7 +97,7 @@ export default function Page() {
     <>
       <Navbar titles={["Dev", "Tech", "Projects"]} />
       <Section>
-        <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-6xl -translate-x-1/2 overflow-hidden ">
+        <div className="absolute left-1/2 top-0 z-0 h-[50%] w-full max-w-7xl -translate-x-1/2 overflow-hidden ">
           <svg
             className="absolute inset-0 h-full w-full"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/event-card/event-card.tsx
+++ b/src/components/event-card/event-card.tsx
@@ -204,7 +204,7 @@ export const EventCard: React.FC<EventCardProps> = ({
         </div>
       </div>
       <div className="mt-4 flex justify-center">
-        <Button variant="outline" className="rounded-xl">
+        <Button className="rounded-xl">
           {isScheduled ? "Registrate aquí" : "Más información"}
         </Button>
       </div>

--- a/src/components/events-section/events-section.tsx
+++ b/src/components/events-section/events-section.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { fetchEvents } from "@/services/events";
 
 import { EventsWrapper } from "./events-wrapper";
@@ -5,18 +7,23 @@ import { Glow, GlowContainer, GlowGroup } from "../glow/glow";
 import { Section } from "../section/section";
 import { SectionPagination } from "../section-pagination/section-pagination";
 import { SectionTitle } from "../section-title/section-title";
+import { Button } from "../ui/button";
+
+interface Props {
+  limit: number;
+  currentPage: number;
+  pageLimit?: number;
+  title?: string;
+  hideLink?: boolean;
+}
 
 export default async function EventsSection({
   limit,
   currentPage,
   pageLimit = 5,
   title = "Nuevos eventos",
-}: {
-  limit: number;
-  currentPage: number;
-  pageLimit?: number;
-  title?: string;
-}) {
+  hideLink = false,
+}: Props) {
   const eventsRes = await fetchEvents(limit, currentPage);
 
   const totalPages = Math.min(
@@ -51,7 +58,16 @@ export default async function EventsSection({
           />
         </GlowGroup>
       </GlowContainer>
-      <SectionTitle id={titleId}>{title}</SectionTitle>
+      <div className="flex w-full items-center justify-between pr-4">
+        <SectionTitle id={titleId}>{title}</SectionTitle>
+        {!hideLink && (
+          <Button className="hidden uppercase sm:inline-flex" asChild>
+            <Link href="/eventos" prefetch>
+              Ver todos
+            </Link>
+          </Button>
+        )}
+      </div>
       <EventsWrapper events={docs} />
       <SectionPagination
         scrollId={titleId}
@@ -61,6 +77,13 @@ export default async function EventsSection({
         nextPage={nextPage}
         className="hidden md:flex"
       />
+      {!hideLink && (
+        <Button className="uppercase sm:hidden" asChild>
+          <Link href="/eventos" prefetch>
+            Ver todos
+          </Link>
+        </Button>
+      )}
     </Section>
   );
 }

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -24,7 +24,7 @@ export const Footer: FC<FooterProps> = (props) => {
         props.className,
       )}
     >
-      <div className="mx-auto flex max-w-8xl flex-col items-start gap-4 p-4">
+      <div className="mx-auto flex max-w-7xl flex-col items-start gap-4 p-4">
         <div className="flex items-center justify-center gap-4">
           <div className="flex aspect-square w-10 items-center justify-center rounded-sm bg-primary p-1.5">
             <Image

--- a/src/components/member-card/member-card.tsx
+++ b/src/components/member-card/member-card.tsx
@@ -142,10 +142,7 @@ const MemberCard: React.FC<MemberCardProps> = (props) => {
           </div>
 
           <div className="flex justify-center">
-            <Button
-              variant="outline"
-              className="rounded-xl text-white transition-colors hover:bg-[#491288]"
-            >
+            <Button className="rounded-xl text-white transition-colors hover:bg-[#491288]">
               Ver Portafolio
             </Button>
           </div>
@@ -198,10 +195,7 @@ const MemberCard: React.FC<MemberCardProps> = (props) => {
           </div>
         </div>
         <div className="flex w-full justify-center">
-          <Button
-            variant="outline"
-            className="rounded-xl text-white transition-colors hover:bg-[#491288]"
-          >
+          <Button className="rounded-xl text-white transition-colors hover:bg-[#491288]">
             Ver Portafolio
           </Button>
         </div>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -24,7 +24,7 @@ export const Navbar: FC<Props> = ({ titles, loopTitles, className }) => {
         className,
       )}
     >
-      <div className="mx-auto flex h-full max-w-8xl items-center justify-between p-4">
+      <div className="mx-auto flex h-full max-w-7xl items-center justify-between p-4">
         <Link href="/" className="font-poppins text-xl">
           <div className="flex items-center justify-center gap-4">
             <div className="flex aspect-square w-10 items-center justify-center rounded-sm p-1.5">

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -11,11 +11,12 @@ import { CsiproLogo } from "../socials/logos/csipro-logo";
 import { Typewriter } from "../typewriter/typewriter";
 
 interface Props {
-  title: string;
+  titles: string[];
+  loopTitles?: boolean;
   className?: HTMLAttributes<HTMLDivElement>["className"];
 }
 
-export const Navbar: FC<Props> = ({ title, className }) => {
+export const Navbar: FC<Props> = ({ titles, loopTitles, className }) => {
   return (
     <nav
       className={cn(
@@ -31,7 +32,7 @@ export const Navbar: FC<Props> = ({ title, className }) => {
             </div>
             <BrandingHeader className="text-xl font-normal">
               <BrandingHeaderTitle>CSI PRO</BrandingHeaderTitle>
-              <Typewriter text={title} />
+              <Typewriter messages={titles} loop={loopTitles} />
             </BrandingHeader>
           </div>
         </Link>

--- a/src/components/project-card/project-card.tsx
+++ b/src/components/project-card/project-card.tsx
@@ -57,7 +57,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = (props) => {
           </div>
         </div>
         <div className="flex justify-center pt-4">
-          <Button variant="outline">Ver más</Button>
+          <Button>Ver más</Button>
         </div>
       </div>
     </div>

--- a/src/components/projects-section/projects-section.tsx
+++ b/src/components/projects-section/projects-section.tsx
@@ -43,25 +43,31 @@ export default async function ProjectsSection() {
 
   return (
     <Carousel>
-      <CarouselContent className="-ml-4">
-        {projectsRes.docs.map((project) => (
-          <CarouselItem
-            key={project.id}
-            className="basis-5/6 sm:basis-3/4 md:basis-[45%] md:pl-8 lg:basis-[30%]"
-          >
-            <ProjectCard
+      <div className="relative">
+        {/* Left fade */}
+        <div className="pointer-events-none absolute left-0 top-0 z-10 hidden h-full w-16 bg-gradient-to-r from-white/90 to-transparent dark:from-muted lg:block" />
+        {/* Right fade */}
+        <div className="pointer-events-none absolute right-0 top-0 z-10 hidden h-full w-16 bg-gradient-to-l from-white/90 to-transparent dark:from-muted lg:block" />
+        <CarouselContent className="-ml-4">
+          {projectsRes.docs.map((project) => (
+            <CarouselItem
               key={project.id}
-              name={project.nombre}
-              subtitle={project.subtitulo}
-              systemType={project.tipo_sistema}
-              stack={project.tecnologias ?? []}
-              thumbnail={project.imagen_principal}
-            />
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselPrevious className="left-0 top-[45%] hidden size-11 disabled:hidden sm:inline-flex" />
-      <CarouselNext className="right-0 top-[45%] hidden size-11 disabled:hidden sm:inline-flex" />
+              className="basis-5/6 sm:basis-3/4 md:basis-[45%] md:pl-8 lg:basis-[30%]"
+            >
+              <ProjectCard
+                key={project.id}
+                name={project.nombre}
+                subtitle={project.subtitulo}
+                systemType={project.tipo_sistema}
+                stack={project.tecnologias ?? []}
+                thumbnail={project.imagen_principal}
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </div>
+      <CarouselPrevious className="left-2 top-[45%] z-10 hidden size-11 disabled:hidden sm:inline-flex" />
+      <CarouselNext className="right-2 top-[45%] z-10 hidden size-11 disabled:hidden sm:inline-flex" />
       <CarouselNavigation name="Projects" />
     </Carousel>
   );

--- a/src/components/section-title/section-title.tsx
+++ b/src/components/section-title/section-title.tsx
@@ -5,12 +5,18 @@ import { cn } from "@/lib/utils";
 interface Props {
   children: ReactNode;
   className?: HTMLAttributes<HTMLHeadingElement>["className"];
+  wrapperClassName?: string;
   id?: string;
 }
 
-export const SectionTitle: FC<Props> = ({ children, className, id }) => {
+export const SectionTitle: FC<Props> = ({
+  children,
+  className,
+  id,
+  wrapperClassName,
+}) => {
   return (
-    <div className="flex w-full py-4">
+    <div className={cn("flex w-full py-4", wrapperClassName)}>
       <h2
         id={id}
         className={cn(

--- a/src/components/section/section.tsx
+++ b/src/components/section/section.tsx
@@ -18,7 +18,7 @@ export const Section: FC<Props> = (props) => {
     >
       <div
         className={cn(
-          "flex w-full max-w-8xl flex-col items-center justify-center gap-4 lg:border-x lg:border-white lg:border-opacity-10",
+          "flex w-full max-w-7xl flex-col items-center justify-center gap-4 lg:border-x lg:border-white lg:border-opacity-10",
           props.classNameDiv,
         )}
       >

--- a/src/components/typewriter/typewriter.tsx
+++ b/src/components/typewriter/typewriter.tsx
@@ -8,19 +8,37 @@ import { BrandingHeaderHighlight } from "../branding-header/branding-header";
 
 interface TypewriterProps {
   className?: HTMLAttributes<HTMLDivElement>["className"];
-  text: string;
+  messages: string[];
+  loop?: boolean;
 }
 
-export const Typewriter: React.FC<TypewriterProps> = ({ text, className }) => {
+export const Typewriter: React.FC<TypewriterProps> = ({
+  messages,
+  loop = false,
+  className,
+}) => {
   return (
     <BrandingHeaderHighlight className={cn("font-medium uppercase", className)}>
       <TypewriterEffect
         onInit={(typewriter) => {
-          typewriter.typeString(text).start();
+          if (messages.length === 0) {
+            return;
+          }
+
+          typewriter.typeString(messages[0]).pauseFor(2000);
+
+          if (messages.length > 1) {
+            for (let i = 1; i < messages.length; i++) {
+              typewriter.deleteAll().typeString(messages[i]).pauseFor(2000);
+            }
+          }
+
+          typewriter.start();
         }}
         options={{
           cursor: "",
           delay: 50,
+          loop,
         }}
       />
     </BrandingHeaderHighlight>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,8 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "bg-primary text-white hover:bg-primary/90",
+        outline:
+          "border-2 border-primary text-primary shadow-xs font-bold hover:text-white hover:bg-primary/90",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -197,7 +197,7 @@ CarouselItem.displayName = "CarouselItem";
 const CarouselPrevious = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+>(({ className, variant = "default", size = "icon", ...props }, ref) => {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
@@ -226,7 +226,7 @@ CarouselPrevious.displayName = "CarouselPrevious";
 const CarouselNext = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+>(({ className, variant = "default", size = "icon", ...props }, ref) => {
   const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -52,7 +52,7 @@ const PaginationLink = ({
     aria-current={isActive ? "page" : undefined}
     className={cn(
       buttonVariants({
-        variant: isActive ? "outline" : "ghost",
+        variant: isActive ? "default" : "ghost",
         size,
       }),
       "rounded-full p-2",


### PR DESCRIPTION
## Describe your changes

Adds missing links to subpages like `/proyectos`, `/eventos`, and `/nosotros`. Updates the navbar to support animating through multiple titles. Decreases `<Section />`'s max width and refactors the main page's hero to fit better in smaller desktop screens.

## What was done in this pull request

- [x] Added missing links to subpages.
- [x] `<Navbar />` now supports multiple titles and animates through them. It can also be configured to loop through the titles indefinitely.
- [x] Decreases the `<Section />` max width to `7xl` (`80rem` or `1280px`).
- [x] Adjusts the main page's hero spacings to fit better in smaller desktop screens.
- [x] Restores the `<Button />` outline variant.
- [x] Adds a fade effect to the `<ProjectsSection />` carousel for desktop.

## Demo / Screenshot / Video

![image](https://github.com/user-attachments/assets/c4571303-4250-4772-bb7d-193e7b55f200)
![image](https://github.com/user-attachments/assets/c8fbbe41-a664-46fe-85fb-65e86d999de5)
![image](https://github.com/user-attachments/assets/e00a1c2e-fe0d-4305-98b3-849fe31b88c6)

